### PR TITLE
Create CITATION.cff and sync with .zenodo.json

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,14 @@
+name: cffconvert
+
+on: push
+
+jobs:
+  verify:
+    name: "cffconvert"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out a copy of the repository
+
+      - uses: citation-file-format/cffconvert-github-action@master
+        name: Check whether the citation metadata from CITATION.cff is equivalent to that in .zenodo.json

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,20 +1,21 @@
 {
-   "creators": [
-      {
-         "affiliation": "Netherlands eScience Center",
-         "name": "Huber, Florian",
-         "orcid": "0000-0002-3535-9406"
-      }
-   ],
-   "description": "Python library to define and generate synthetic time series data",
-   "keywords": [
-      "python",
-      "time series",
-      "synthetic data",
-      "machine learning"
-   ],
-   "license": {
-      "id": "Apache-2.0"
-   },
-   "title": "time_series_generator"
+    "creators": [
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Huber, Florian",
+            "orcid": "0000-0002-3535-9406"
+        }
+    ],
+    "description": "Python library to define and generate synthetic time series data",
+    "keywords": [
+        "Python",
+        "synthetic data",
+        "time series analysis",
+        "machine learning",
+        "classification"
+    ],
+    "license": {
+        "id": "Apache-2.0"
+    },
+    "title": "time_series_generator"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+# YAML 1.2
+---
+abstract: "Python library to define and generate synthetic time series data"
+authors: 
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Huber
+    given-names: Florian
+    orcid: "https://orcid.org/0000-0002-3535-9406"
+cff-version: "1.1.0"
+date-released: 11-03-2021
+doi: "10.0000/FIXME"
+keywords: 
+  - "time series analysis"
+  - "machine learning"
+  - classification
+license: "Apache-2.0"
+message: "If you use this software, please cite it using these metadata."
+repository-code: "https://github.com/epodium/time_series_generator"
+title: "time_series_generator"
+version: "0.1.0"
+...

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-3535-9406"
 cff-version: "1.1.0"
 date-released: 2021-03-11
-doi: "10.0000/FIXME"
+doi: "10.5281/zenodo.4596774"
 keywords: 
   - Python
   - "synthetic data"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,8 @@ cff-version: "1.1.0"
 date-released: 2021-03-11
 doi: "10.0000/FIXME"
 keywords: 
+  - Python
+  - "synthetic data"
   - "time series analysis"
   - "machine learning"
   - classification

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
     given-names: Florian
     orcid: "https://orcid.org/0000-0002-3535-9406"
 cff-version: "1.1.0"
-date-released: 11-03-2021
+date-released: 2021-03-11
 doi: "10.0000/FIXME"
 keywords: 
   - "time series analysis"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4596774.svg)](https://doi.org/10.5281/zenodo.4596774)
+
+
+
 # Time Series Generator
 Create synthetic time series data of defined type (or class).
 


### PR DESCRIPTION
In this PR:
- I added a `CITATION.cff` file with more or less equivalent data to what was there in `.zenodo.json`. 
- I then added the `cffconvert` workflow that monitors equivalence between `CITATION.cff` and `.zenodo.json`. https://github.com/marketplace/actions/cffconvert
- I then fixed what the workflow complained about.
