### PR TITLE
fixed yaml load warning

### DIFF
--- a/ts_generator/TS_generator.py
+++ b/ts_generator/TS_generator.py
@@ -71,7 +71,7 @@ def load_TS_class(filename,
     """
 
     with open(filename, 'r') as ymlfile:
-        TS_def = yaml.load(ymlfile)
+        TS_def = yaml.load(ymlfile, Loader=yaml.SafeLoader)
 
     if print_info:
         print(TS_def['class_name'])


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: #12 

**Describe the changes made in this pull request**

Defined a loader in a yaml.load() call to avoid a deprecation warning

**Instructions to review the pull request**

1. Run the notebook `TS_generation_example.ipynb`. It should give a warning after line `TSC_02 = TSgen.load_TS_class(filename)` : `ts_generator/TS_generator.py:74: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated`
2. install this PR
3. Rerun the notebook `TS_generation_example.ipynb`. The warning should have disappeared
